### PR TITLE
Init a no-op Babel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # babel-plugin-fn-counter
 a simple plugin counter
+
+## Installation
+To install the plugin, use npm:
+
+```sh
+npm install babel-plugin-fn-counter
+```
+
+## Usage
+To use the plugin in your Babel configuration file, add it to the plugins array:
+
+```js
+{
+  "plugins": ["babel-plugin-fn-counter"]
+}
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install babel-plugin-fn-counter
 ```
 
 ## Usage
-To use the plugin in your Babel configuration file, add it to the plugins array:
+To use the plugin in your Babel configuration file (usually named "babel.config.json" or ".babelrc" and located at the root of your project), add it to the plugins array:
 
 ```js
 {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "babel-plugin-fn-counter",
+  "version": "1.0.0",
+  "description": "A simple Babel plugin counter",
+  "main": "src/index.js",
+  "dependencies": {}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,15 @@
+module.exports = function() {
+  return {
+    visitor: {
+      FunctionDeclaration(path) {
+        // No-op
+      },
+      FunctionExpression(path) {
+        // No-op
+      },
+      ArrowFunctionExpression(path) {
+        // No-op
+      }
+    }
+  };
+};


### PR DESCRIPTION
Add initial implementation of a no-op Babel plugin

* **package.json**
  - Add `name`, `version`, `description`, `main`, and `dependencies` fields.

* **src/index.js**
  - Add a module export function returning an object with a `visitor` property.
  - Add `FunctionDeclaration`, `FunctionExpression`, and `ArrowFunctionExpression` properties inside the `visitor` object with empty functions.

* **README.md**
  - Add `## Installation` section with npm installation instructions.
  - Add `## Usage` section with instructions and code example for using the plugin in a Babel configuration file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/renaesop/babel-plugin-fn-counter/pull/1?shareId=d45a1072-becf-4438-aab1-76634eba6db8).

## Summary by Sourcery

Implement a no-op Babel plugin that visits function declarations, function expressions, and arrow function expressions.

New Features:
- Introduce a Babel plugin that currently performs no operation but is structured to visit and potentially modify function declarations, function expressions, and arrow function expressions.
- Add documentation for installing and using the plugin.