### PR TITLE
Fix runtime execution of __fn__counter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,15 +40,6 @@ module.exports = function() {
         const functionName = path.node.id ? path.node.id.name : 'anonymous';
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
         path.insertBefore(`
-          if (typeof __fn__counter === 'undefined') {
-            if (typeof global !== 'undefined') {
-              global.__fn__counter = {};
-            } else if (typeof window !== 'undefined') {
-              window.__fn__counter = {};
-            } else if (typeof self !== 'undefined') {
-              self.__fn__counter = {};
-            }
-          }
           if (!__fn__counter['${uniqueKey}']) {
             __fn__counter['${uniqueKey}'] = 0;
           }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = function() {
         const functionName = path.node.id.name;
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
         path.insertBefore(`
-          if (!__fn__counter['${uniqueKey}']) {
+          if (typeof __fn__counter['${uniqueKey}'] === 'undefined') {
             __fn__counter['${uniqueKey}'] = 0;
           }
           __fn__counter['${uniqueKey}']++;
@@ -41,7 +41,7 @@ module.exports = function() {
         const functionName = 'arrow_function';
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
         path.insertBefore(`
-          if (!__fn__counter['${uniqueKey}']) {
+          if (typeof __fn__counter['${uniqueKey}'] === 'undefined') {
             __fn__counter['${uniqueKey}'] = 0;
           }
           __fn__counter['${uniqueKey}']++;

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,6 @@ module.exports = function() {
         const functionName = path.node.id.name;
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
         path.insertBefore(`
-          if (typeof __fn__counter === 'undefined') {
-            if (typeof global !== 'undefined') {
-              global.__fn__counter = {};
-            } else if (typeof window !== 'undefined') {
-              window.__fn__counter = {};
-            } else if (typeof self !== 'undefined') {
-              self.__fn__counter = {};
-            }
-          }
           if (!__fn__counter['${uniqueKey}']) {
             __fn__counter['${uniqueKey}'] = 0;
           }
@@ -50,15 +41,6 @@ module.exports = function() {
         const functionName = 'arrow_function';
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
         path.insertBefore(`
-          if (typeof __fn__counter === 'undefined') {
-            if (typeof global !== 'undefined') {
-              global.__fn__counter = {};
-            } else if (typeof window !== 'undefined') {
-              window.__fn__counter = {};
-            } else if (typeof self !== 'undefined') {
-              self.__fn__counter = {};
-            }
-          }
           if (!__fn__counter['${uniqueKey}']) {
             __fn__counter['${uniqueKey}'] = 0;
           }

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,78 @@
-let __fn__counter = {};
-
 const sourceMap = require('source-map');
 
 module.exports = function() {
   return {
     visitor: {
+      Program(path, state) {
+        const initCounter = `
+          if (typeof __fn__counter === 'undefined') {
+            if (typeof global !== 'undefined') {
+              global.__fn__counter = {};
+            } else if (typeof window !== 'undefined') {
+              window.__fn__counter = {};
+            } else if (typeof self !== 'undefined') {
+              self.__fn__counter = {};
+            }
+          }
+        `;
+        path.unshiftContainer('body', initCounter);
+      },
       FunctionDeclaration(path, state) {
         const functionName = path.node.id.name;
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
-        if (!__fn__counter[uniqueKey]) {
-          __fn__counter[uniqueKey] = 0;
-        }
-        __fn__counter[uniqueKey]++;
+        path.insertBefore(`
+          if (typeof __fn__counter === 'undefined') {
+            if (typeof global !== 'undefined') {
+              global.__fn__counter = {};
+            } else if (typeof window !== 'undefined') {
+              window.__fn__counter = {};
+            } else if (typeof self !== 'undefined') {
+              self.__fn__counter = {};
+            }
+          }
+          if (!__fn__counter['${uniqueKey}']) {
+            __fn__counter['${uniqueKey}'] = 0;
+          }
+          __fn__counter['${uniqueKey}']++;
+        `);
       },
       FunctionExpression(path, state) {
         const functionName = path.node.id ? path.node.id.name : 'anonymous';
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
-        if (!__fn__counter[uniqueKey]) {
-          __fn__counter[uniqueKey] = 0;
-        }
-        __fn__counter[uniqueKey]++;
+        path.insertBefore(`
+          if (typeof __fn__counter === 'undefined') {
+            if (typeof global !== 'undefined') {
+              global.__fn__counter = {};
+            } else if (typeof window !== 'undefined') {
+              window.__fn__counter = {};
+            } else if (typeof self !== 'undefined') {
+              self.__fn__counter = {};
+            }
+          }
+          if (!__fn__counter['${uniqueKey}']) {
+            __fn__counter['${uniqueKey}'] = 0;
+          }
+          __fn__counter['${uniqueKey}']++;
+        `);
       },
       ArrowFunctionExpression(path, state) {
         const functionName = 'arrow_function';
         const uniqueKey = `${state.file.opts.filename}:${functionName}:${path.node.loc.start.line}:${path.node.loc.start.column}`;
-        if (!__fn__counter[uniqueKey]) {
-          __fn__counter[uniqueKey] = 0;
-        }
-        __fn__counter[uniqueKey]++;
+        path.insertBefore(`
+          if (typeof __fn__counter === 'undefined') {
+            if (typeof global !== 'undefined') {
+              global.__fn__counter = {};
+            } else if (typeof window !== 'undefined') {
+              window.__fn__counter = {};
+            } else if (typeof self !== 'undefined') {
+              self.__fn__counter = {};
+            }
+          }
+          if (!__fn__counter['${uniqueKey}']) {
+            __fn__counter['${uniqueKey}'] = 0;
+          }
+          __fn__counter['${uniqueKey}']++;
+        `);
       }
     }
   };


### PR DESCRIPTION
Update `__fn__counter` to be initialized and incremented at runtime instead of during Babel transformation.

* Remove the global declaration of `__fn__counter` in `src/index.js`.
* Add code to insert `__fn__counter` initialization at the beginning of the program.
* Add code to increment `__fn__counter` at runtime for each function declaration, function expression, and arrow function expression.
* Ensure `__fn__counter` is correctly initialized in different environments (Node.js, browser, web worker).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/renaesop/babel-plugin-fn-counter/pull/6?shareId=e6b2e463-e409-4576-9974-e302e6d40157).