### PR TITLE
Add GitHub action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # babel-plugin-fn-counter
 a simple plugin counter
 
+![Node.js CI](https://github.com/renaesop/babel-plugin-fn-counter/actions/workflows/node.js.yml/badge.svg)
+
 ## Installation
 To install the plugin, use npm:
 


### PR DESCRIPTION
Add GitHub action badge to `README.md`.

* Add Node.js CI badge markdown to the top of the `README.md` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/renaesop/babel-plugin-fn-counter/pull/8?shareId=0fe5140d-bfe8-40db-9e78-df7d46a7d535).